### PR TITLE
change variable used in template to generate rolebinding resource

### DIFF
--- a/helm-chart/templates/rbac.yaml
+++ b/helm-chart/templates/rbac.yaml
@@ -25,6 +25,6 @@ roleRef:
   name: {{ .metadata.name }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .metadata.name }}
+    name: {{ .serviceAccountName }}
     namespace: {{ .metadata.namespace }}
 {{- end }}


### PR DESCRIPTION
In values, there is a dedicated property for the name of the service account that should be bound to the role but it wasn't use in the rbac template.