### PR TITLE
Working autoaffiliate POC for FC and existing users

### DIFF
--- a/api/src/repositories/affiliation.repository.ts
+++ b/api/src/repositories/affiliation.repository.ts
@@ -26,12 +26,13 @@ export class AffiliationRepository extends DefaultCrudRepository<
    * Creates affiliation based on enterpriseEmail, enterpriseId and enterprise manual affiliation
    * @param citizen Citizen
    * @param hasManualAffiliation boolean
+   * @param isAutoAffiliated boolean
    * @returns Promise<Affiliation>
    */
-  async createAffiliation(citizen: Citizen, hasManualAffiliation: boolean): Promise<Affiliation> {
-    // Create object : affiliation
+  async createAffiliation(citizen: Citizen, hasManualAffiliation: boolean, isAutoAffiliated?: boolean): Promise<Affiliation> {
+     // Create object : affiliation
     const rawAffiliation: Affiliation = new Affiliation(citizen.affiliation);
-    // Set enterpriseEmail & enterpriseId to null if not present
+   // Set enterpriseEmail & enterpriseId to null if not present
     rawAffiliation.enterpriseEmail = rawAffiliation?.enterpriseEmail || null;
     rawAffiliation.enterpriseId = rawAffiliation?.enterpriseId || null;
 
@@ -43,6 +44,10 @@ export class AffiliationRepository extends DefaultCrudRepository<
       rawAffiliation.status = AFFILIATION_STATUS.TO_AFFILIATE;
     } else {
       rawAffiliation.status = AFFILIATION_STATUS.UNKNOWN;
+    }
+
+    if (isAutoAffiliated) {
+      rawAffiliation.status = AFFILIATION_STATUS.AFFILIATED;
     }
 
     // Assign citizenId

--- a/website/src/apiMob/CitizenService.ts
+++ b/website/src/apiMob/CitizenService.ts
@@ -121,6 +121,17 @@ export const requestCitizenAffiliation = async (
   return data;
 };
 
+export const requestCitizenAutoAffiliation = async (
+  citizenId: string,
+  enterpriseId: string
+): Promise<{}> => {
+  const { data } = await https.post(
+    `v1/citizens/${citizenId}/autoaffiliate`,
+    JSON.stringify({ enterpriseId })
+  );
+  return data;
+};
+
 export const requestCitizenDesaffiliation = async (
   citizenId: string
 ): Promise<{}> => {

--- a/website/src/pages/redirection.ts
+++ b/website/src/pages/redirection.ts
@@ -2,17 +2,33 @@ import { navigate } from 'gatsby';
 
 import { useRoleAccepted } from '@utils/keycloakUtils';
 import { browser } from '@utils/helpers';
+import { useSession, useUser } from '../context';
+import { requestCitizenAutoAffiliation } from '@api/CitizenService';
+import { useQueryParam, StringParam } from 'use-query-params';
 
 import { Roles } from '../constants';
 
 const IndexPage = () => {
-  if (browser) {
-    const isSupervisor = useRoleAccepted(Roles.SUPERVISORS);
-    const isManager = useRoleAccepted(Roles.MANAGERS);
+  // TODO: adding useUser and useQueryParams might have an effect on performances
+  // This might be important for a page that is only supposed to redirect users
+  // Maybe there is a way to be smarter and only check userContext if autoaffiliate param is present ?
+  const { citizen, userFunder, refetchCitizen } = useUser();
+  const [entrepriseId] = useQueryParam('autoaffiliate', StringParam);
 
-    isSupervisor || isManager
-      ? navigate('/mon-dashboard')
-      : navigate('/recherche');
+  if (browser) {
+    if (entrepriseId && citizen) {
+      requestCitizenAutoAffiliation(citizen.id, entrepriseId).then(() => {
+        refetchCitizen()
+        navigate('/recherche/?tab=AideEmployeur')
+      })
+    } else {
+      const isSupervisor = useRoleAccepted(Roles.SUPERVISORS);
+      const isManager = useRoleAccepted(Roles.MANAGERS);
+  
+      isSupervisor || isManager
+        ? navigate('/mon-dashboard')
+        : navigate('/recherche');
+    }
   }
   return null;
 };


### PR DESCRIPTION
This is a proof of concept of using a magic link to automatically affiliate users to their employer.

The magic link is a regular auth link, with a specific query parameter passed to the redirect page, e.g:

```
/auth/realms/mcm/protocol/openid-connect/auth?client_id=platform&response_mode=fragment&response_type=code&login=true&redirect_uri=http://localhost:8000/redirection/?autoaffiliate=2219e721-ac71-4a65-a202-37675c74ba58
```

The new param `autoaffiliate` contains the entrepriseID that will be linked to the user.

When present on redirect, the user is automatically affiliated, without the need to specify a work email or manual validation. The user is also redirected to its employer incentives page.

Note: this only works for existing account, or accounts created with FranceConnect. Creating a new account using the moB form breaks the context, and we lose track of the autoaffiliate param.

Demo:
![Peek 2024-09-20 18-09](https://github.com/user-attachments/assets/ced38152-d5e0-4035-8810-f585067c4222)
